### PR TITLE
Make `make build` work again

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/mitchellh/packer/packer/plugin"
+import "github.com/hashicorp/packer/packer/plugin"
 
 func main() {
 	server, err := plugin.Server()

--- a/post-processor.go
+++ b/post-processor.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/mitchellh/packer/helper/config"
-	"github.com/mitchellh/packer/packer"
-	"github.com/mitchellh/packer/template/interpolate"
+	"github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
 )
 
 // Config is the post-processor configuration with interpolation supported.

--- a/updater.go
+++ b/updater.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/hashicorp/packer/packer"
 	"github.com/jeffail/gabs"
-	"github.com/mitchellh/packer/packer"
 )
 
 // UpdateJSONFile sets the value of the JSON paths within the specified file

--- a/updater_test.go
+++ b/updater_test.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-  "github.com/jeffail/gabs"
-	"github.com/mitchellh/packer/packer"
+	"github.com/hashicorp/packer/packer"
+	"github.com/jeffail/gabs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +25,7 @@ func TestUpdateJSONFileShouldReturnErrorWhenFileDoesNotExist(t *testing.T) {
 
 func TestUpdateJSONFileShouldSetValuesOnMultiPaths(t *testing.T) {
 	file := "testdata/test/update_json_file.json"
-	paths := []string{"variables.variable1","variables.variable2"}
+	paths := []string{"variables.variable1", "variables.variable2"}
 	ui := &packer.BasicUi{
 		Reader:      new(bytes.Buffer),
 		Writer:      new(bytes.Buffer),


### PR DESCRIPTION
With the new OSX upgrade(High Sierra), the old binary file failed to work, complaining:

```
2017/10/02 08:50:05 Starting plugin: /Users/xiaket/.xiaket/etc/bin/packer-post-processor-json-updater []string{"/Users/xiaket/.xiaket/etc/bin
/packer-post-processor-json-updater"}
2017/10/02 08:50:05 Waiting for RPC address for: /Users/xiaket/.xiaket/etc/bin/packer-post-processor-json-updater
2017/10/02 08:50:05 packer-post-processor-json-updater: failed MSpanList_Insert 0xb08000 0x87ea0e440fa 0x0 0x0
2017/10/02 08:50:05 packer-post-processor-json-updater: fatal error: MSpanList_Insert
```
I can confirm that my local binary file has the same checksum as the one provided in the release section.

In order to build the post processor again, I have to tweak some imports. I also did a `make style` to clean up some formatting, but that's all I have done. `make build` can produce the binary files in ther release section, I've also tested my local build(darwin/amd64) and it worked.

I would also suggest an update in `Godeps` dir is in order.